### PR TITLE
Updated node-geocoder to version 3.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/ghaiklor/sails-service-location#readme",
   "dependencies": {
     "lodash": "3.10.1",
-    "node-geocoder": "3.3.0"
+    "node-geocoder": "3.4.0"
   },
   "devDependencies": {
     "babel": "5.8.23",


### PR DESCRIPTION
:rocket:

node-geocoder just published version 3.4.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 5 commits (ahead by 5, behind by 0).
- [28652a8](https://github.com/nchaulet/node-geocoder/commit/28652a8b7707a475b25823a90de2173f9adc59a5): 3.4.0
- [233d393](https://github.com/nchaulet/node-geocoder/commit/233d39372af0ff77f4aca5db26b7bf2114b4abcf): v3.4.0 changelog
- [edddd99](https://github.com/nchaulet/node-geocoder/commit/edddd9960d35983242c480febf77a38248618b46): Merge pull request #135 from magnushiie/master
- [e6e7e9d](https://github.com/nchaulet/node-geocoder/commit/e6e7e9d8741bcd210f81b04ed75b756048a38bae): Add Teleport geocoder
- [97fc0be](https://github.com/nchaulet/node-geocoder/commit/97fc0be9055df9afabcbdd169d2bff674e2f46af): Update CHANGELOG.md

See the [full diff](https://github.com/nchaulet/node-geocoder/compare/da161d320f5c175338a5374f8952c3e46ca608f3...28652a8b7707a475b25823a90de2173f9adc59a5).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
